### PR TITLE
Implement utility that converts from the config object to its ini format representation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 
 test: &test
-  working_directory: /go/src/github.com/peterebden/gcfg
+  working_directory: /go/src/github.com/please-build/gcfg
   steps:
     - checkout
     - run: go version

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
 Gcfg reads INI-style configuration files into Go structs;
 supports user-defined types and subsections.
 
-Package docs: https://godoc.org/github.com/peterebden/gcfg
+Package docs: https://godoc.org/github.com/please-build/gcfg

--- a/doc.go
+++ b/doc.go
@@ -142,4 +142,4 @@
 //    - make error context accessible programmatically?
 //    - limit input size?
 //
-package gcfg // import "github.com/peterebden/gcfg"
+package gcfg // import "github.com/please-build/gcfg"

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/please-build/gcfg
 
 go 1.16
 
-require gopkg.in/warnings.v0 v0.1.2
+require (
+	github.com/stretchr/testify v1.7.0 // indirect
+	gopkg.in/warnings.v0 v0.1.2
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,13 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/read_test.go
+++ b/read_test.go
@@ -488,7 +488,7 @@ func TestStringStringMapSection(t *testing.T) {
 
 func TestFatalOnly(t *testing.T) {
 	var s = struct {
-		Foo struct{
+		Foo struct {
 			Bar string
 		}
 	}{}

--- a/read_test.go
+++ b/read_test.go
@@ -131,6 +131,8 @@ var readtests = []struct {
 	tests []readtest
 }{{"scanning", []readtest{
 	{"[section]\nname=value", &cBasic{Section: cBasicS1{Name: "value"}}, true},
+	// hash sign in value
+	{"[section]\nname=\"val#ue\"", &cBasic{Section: cBasicS1{Name: "val#ue"}}, true},
 	// hyphen in name
 	{"[hyphen-in-section]\nhyphen-in-name=value", &cBasic{Hyphen_In_Section: cBasicS2{Hyphen_In_Name: "value"}}, true},
 	// quoted string value

--- a/scanner/example_test.go
+++ b/scanner/example_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 import (
-	"github.com/peterebden/gcfg/scanner"
-	"github.com/peterebden/gcfg/token"
+	"github.com/please-build/gcfg/scanner"
+	"github.com/please-build/gcfg/token"
 )
 
 func ExampleScanner_Scan() {

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 import (
-	"github.com/peterebden/gcfg/token"
+	"github.com/please-build/gcfg/token"
 )
 
 var fset = token.NewFileSet()

--- a/stringify.go
+++ b/stringify.go
@@ -1,0 +1,220 @@
+package gcfg
+
+import (
+	"encoding"
+	"fmt"
+	"math/big"
+	"reflect"
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// Stringify returns the ini format representation of `config`.
+func Stringify(config interface{}) (string, error) {
+	configPtr := reflect.ValueOf(config)
+	if configPtr.Kind() != reflect.Ptr || configPtr.Elem().Kind() != reflect.Struct {
+		return "", fmt.Errorf("Config must be a pointer to a struct")
+	}
+	configValue := configPtr.Elem()
+
+	var s string
+	for i := 0; i < configValue.NumField(); i++ {
+		fieldValue := configValue.Field(i)
+		fieldStruct := configValue.Type().Field(i)
+		if !fieldStruct.IsExported() {
+			continue
+		}
+
+		iniFieldName := iniKey(fieldStruct)
+
+		if fieldValue.Kind() == reflect.Struct {
+			res, err := stringifyStructFields(fieldValue)
+			if err != nil {
+				return "", err
+			}
+
+			s += fmt.Sprintf("[%s]\n%s\n", iniFieldName, res)
+		} else if fieldValue.Kind() == reflect.Map {
+			if fieldStruct.Type.Key().Kind() != reflect.String {
+				return "", fmt.Errorf("The map keys must to be of string type, instead they are of %s type", fieldStruct.Type.Key().Kind())
+			}
+
+			if fieldStruct.Type.Elem().Kind() == reflect.String {
+				// We encode subsections and variables using the `subsection variable` format
+				// in map keys, if we define subsections on the ini file where the underlying
+				// type is map[string]string. We need to decode this from the config object
+				// to convert it back to the ini format.
+				mapTree := make(map[string]map[string]string)
+				iter := fieldValue.MapRange()
+				for iter.Next() {
+					parts := strings.Split(iter.Key().String(), " ")
+					if len(parts) > 2 {
+						panic("Invalid map key value")
+					}
+
+					var subsection string
+					var variable string
+					if len(parts) == 1 {
+						variable = parts[0]
+					} else {
+						subsection = parts[0]
+						variable = parts[1]
+					}
+					if _, exists := mapTree[subsection]; !exists {
+						mapTree[subsection] = make(map[string]string)
+					}
+					mapTree[subsection][variable] = iter.Value().String()
+				}
+
+				for subsection, variables := range mapTree {
+					if subsection == "" {
+						s += fmt.Sprintf("[%s]\n", iniFieldName)
+					} else {
+						s += fmt.Sprintf("[%s \"%s\"]\n", iniFieldName, subsection)
+					}
+					for variable, value := range variables {
+						s += fmt.Sprintf("%s=%s\n", variable, value)
+					}
+					s += "\n"
+				}
+			} else if fieldStruct.Type.Elem().Kind() == reflect.Ptr && fieldStruct.Type.Elem().Elem().Kind() == reflect.Struct {
+				iter := fieldValue.MapRange()
+				for iter.Next() {
+					res, err := stringifyStructFields(iter.Value().Elem())
+					if err != nil {
+						return "", err
+					}
+
+					if iter.Key().String() == "" {
+						s += fmt.Sprintf("[%s]\n", iniFieldName)
+					} else {
+						s += fmt.Sprintf("[%s \"%s\"]\n", iniFieldName, iter.Key())
+					}
+					s += res + "\n"
+				}
+			} else {
+				return "", fmt.Errorf("The map values must either be of string or *struct type, instead they are of %s type", fieldStruct.Type.Elem().Kind())
+			}
+		}
+	}
+
+	return s, nil
+}
+
+func stringifyStructFields(value reflect.Value) (string, error) {
+	if value.Kind() != reflect.Struct {
+		return "", fmt.Errorf("Expected a struct type from %v, but instead got %s\n", value, value.Kind())
+	}
+
+	var s string
+	for i := 0; i < value.NumField(); i++ {
+		fieldValue := value.Field(i)
+		fieldStruct := value.Type().Field(i)
+		if !fieldStruct.IsExported() {
+			continue
+		}
+
+		if fieldStruct.Tag.Get("gcfg") == "extra_values" {
+			if fieldStruct.Type != reflect.TypeOf(map[string]string{}) && fieldStruct.Type != reflect.TypeOf(map[string][]string{}) {
+				return "", fmt.Errorf("Expected either a map[string]string or map[string][]string type, but instead got %s\n", fieldStruct.Type)
+			}
+
+			iter := fieldValue.MapRange()
+			for iter.Next() {
+				key := iter.Key()
+				value := iter.Value()
+				if value.Kind() == reflect.String {
+					s += fmt.Sprintf("%s=%s\n", key, value)
+				} else {
+					for j := 0; j < value.Len(); j++ {
+						s += fmt.Sprintf("%s=%s\n", key, value.Index(j))
+					}
+				}
+			}
+		} else {
+			if err := iterateMaybeSlice(fieldValue, func(innerValue reflect.Value) error {
+				res, err := iniValue(innerValue)
+				if err != nil {
+					return err
+				}
+				s += fmt.Sprintf("%s=%s\n", iniKey(fieldStruct), res)
+				return nil
+			}); err != nil {
+				return "", err
+			}
+		}
+	}
+
+	return s, nil
+}
+
+// This function implements the inversion of `fieldFold`.
+func iniKey(fieldStruct reflect.StructField) string {
+	tag := newTag(fieldStruct.Tag.Get("gcfg"))
+	if tag.ident != "" {
+		return tag.ident
+	}
+
+	name := fieldStruct.Name
+	firstRune, firstRuneSize := utf8.DecodeRuneInString(name)
+	if firstRune == 'X' {
+		secondRune, _ := utf8.DecodeRuneInString(name[firstRuneSize:])
+		if unicode.IsLetter(secondRune) && !unicode.IsLower(secondRune) && !unicode.IsUpper(secondRune) {
+			name = name[firstRuneSize:]
+		}
+	}
+
+	return strings.ToLower(strings.Replace(name, "_", "-", -1))
+}
+
+// This function implements the inversion of `setters`.
+func iniValue(value reflect.Value) (string, error) {
+	if bigIntValue, ok := value.Interface().(big.Int); ok {
+		return bigIntValue.String(), nil
+	}
+
+	if v, exists := value.Interface().(encoding.TextMarshaler); exists {
+		res, err := v.MarshalText()
+		if err != nil {
+			return "", fmt.Errorf("Failed to marshal text: %s", err)
+		}
+
+		return string(res), nil
+	}
+
+	switch value.Kind() {
+	case reflect.String:
+		return value.String(), nil
+
+	case reflect.Bool:
+		if value.Bool() {
+			return "true", nil
+		}
+		return "false", nil
+
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return strconv.FormatInt(value.Int(), 10), nil
+
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return strconv.FormatUint(value.Uint(), 10), nil
+	}
+
+	return "", fmt.Errorf("Unable to stringify value: %+v", value.Interface())
+}
+
+func iterateMaybeSlice(value reflect.Value, callback func(reflect.Value) error) error {
+	if value.Kind() == reflect.Slice {
+		for i := 0; i < value.Len(); i++ {
+			if err := callback(value.Index(i)); err != nil {
+				return err
+			}
+		}
+	} else {
+		if err := callback(value); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/stringify_test.go
+++ b/stringify_test.go
@@ -17,6 +17,8 @@ type subtypeStruct1 struct {
 	Bar_Foo *big.Int
 	Baz_Baz []string
 	F_Bar   map[string]string `gcfg:"extra_values"`
+	Xǂbar   string
+	Xfoo    string
 	// Private field is here to make sure they aren't picked up.
 	private bool
 }
@@ -66,6 +68,8 @@ bar-foo=10
 baz-baz=value3
 baz-baz=value4
 bar-key=bar-value
+ǂbar=
+xfoo=
 
 `
 
@@ -110,6 +114,8 @@ bar-foo=10
 baz-baz=value3
 baz-baz=value4
 bar-key=bar-value
+ǂbar=
+xfoo=
 
 `
 

--- a/stringify_test.go
+++ b/stringify_test.go
@@ -1,0 +1,175 @@
+package gcfg
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type subtypeStruct1 struct {
+	Bar     string
+	Baz     subtypeStructWithMarshaler
+	FBar    bool `gcfg:"f--bar"`
+	BFoo    bool
+	Bazbar  uint
+	FooBaz  int
+	Bar_Foo *big.Int
+	Baz_Baz []string
+	F_Bar   map[string]string `gcfg:"extra_values"`
+	// Private field is here to make sure they aren't picked up.
+	private bool
+}
+
+type subtypeStructWithMarshaler struct {
+	Value string
+}
+
+func (s subtypeStructWithMarshaler) MarshalText() ([]byte, error) {
+	return []byte(s.Value), nil
+}
+
+type subtypeStruct2 struct {
+	Foobar subtypeStructNoMarshaler
+}
+
+type subtypeStructNoMarshaler struct {
+	Value string
+}
+
+type extraValuesStruct struct {
+	ExtraValues map[string][]string `gcfg:"extra_values"`
+}
+
+func TestStringify1(t *testing.T) {
+	config := &struct {
+		Foo subtypeStruct1
+	}{
+		Foo: subtypeStruct1{
+			Bar:     "value1",
+			Baz:     subtypeStructWithMarshaler{Value: "value2"},
+			FBar:    true,
+			FooBaz:  -5,
+			Bar_Foo: big.NewInt(10),
+			Baz_Baz: []string{"value3", "value4"},
+			F_Bar:   map[string]string{"bar-key": "bar-value"},
+		},
+	}
+	expectedResult := `[foo]
+bar=value1
+baz=value2
+f--bar=true
+bfoo=false
+bazbar=0
+foobaz=-5
+bar-foo=10
+baz-baz=value3
+baz-baz=value4
+bar-key=bar-value
+
+`
+
+	res, err := Stringify(config)
+	assert.NoError(t, err)
+	assert.Equal(t, res, expectedResult)
+}
+
+func TestStringify2(t *testing.T) {
+	config := &struct {
+		Foo subtypeStruct2
+	}{}
+
+	_, err := Stringify(config)
+	assert.Errorf(t, err, "Third-level down structs must fail if they don't implement encoding.TextMarshaler: %v", config)
+}
+
+func TestStringify3(t *testing.T) {
+	config := &struct {
+		Foo map[string]*subtypeStruct1
+	}{
+		Foo: map[string]*subtypeStruct1{
+			"sub": {
+				Bar:     "value1",
+				Baz:     subtypeStructWithMarshaler{Value: "value2"},
+				FBar:    true,
+				FooBaz:  -5,
+				Bar_Foo: big.NewInt(10),
+				Baz_Baz: []string{"value3", "value4"},
+				F_Bar:   map[string]string{"bar-key": "bar-value"},
+			},
+		},
+	}
+	expectedResult := `[foo "sub"]
+bar=value1
+baz=value2
+f--bar=true
+bfoo=false
+bazbar=0
+foobaz=-5
+bar-foo=10
+baz-baz=value3
+baz-baz=value4
+bar-key=bar-value
+
+`
+
+	res, err := Stringify(config)
+	assert.NoError(t, err)
+	assert.Equal(t, res, expectedResult)
+}
+
+func TestStringify4(t *testing.T) {
+	config := &struct {
+		Foo map[string]string
+	}{
+		Foo: map[string]string{"key": "value"},
+	}
+	expectedResult := `[foo]
+key=value
+
+`
+
+	res, err := Stringify(config)
+	assert.NoError(t, err)
+	assert.Equal(t, res, expectedResult)
+}
+
+func TestStringify5(t *testing.T) {
+	config := &struct {
+		Foo map[string]string
+	}{
+		Foo: map[string]string{"sub key": "value"},
+	}
+	expectedResult := `[foo "sub"]
+key=value
+
+`
+
+	res, err := Stringify(config)
+	assert.NoError(t, err)
+	assert.Equal(t, res, expectedResult)
+}
+
+func TestStringify6(t *testing.T) {
+	config := &struct {
+		Bar subtypeStructNoMarshaler
+		Baz extraValuesStruct
+	}{
+		Bar: subtypeStructNoMarshaler{Value: "value1"},
+		Baz: extraValuesStruct{
+			ExtraValues: map[string][]string{"key1": {"value2", "value3"}},
+		},
+	}
+	expectedResult := `[bar]
+value=value1
+
+[baz]
+key1=value2
+key1=value3
+
+`
+
+	res, err := Stringify(config)
+	assert.NoError(t, err)
+	assert.Equal(t, res, expectedResult)
+}

--- a/types/int_test.go
+++ b/types/int_test.go
@@ -24,8 +24,8 @@ func TestParseInt(t *testing.T) {
 		{"a", Hex, int(0xa), true},
 		{"10", Hex, int(0x10), true},
 		{"-0xa", Hex, int(-0xa), true},
-		{"0x", Hex, int(0x0), true},  // Scanf doesn't require digit behind 0x
-		{"-0x", Hex, int(0x0), true}, // Scanf doesn't require digit behind 0x
+		{"0x", Hex, int(0x0), false},
+		{"-0x", Hex, int(0x0), false},
 		{"-a", Hex, int(-0xa), true},
 		{"-10", Hex, int(-0x10), true},
 		{"x", Hex, int(0), false},

--- a/types/scan_test.go
+++ b/types/scan_test.go
@@ -13,7 +13,7 @@ func TestScanFully(t *testing.T) {
 		ok   bool
 	}{
 		{"a", 'v', int(0), false},
-		{"0x", 'v', int(0), true},
+		{"0x", 'v', int(0), false},
 		{"0x", 'd', int(0), false},
 	} {
 		d := reflect.New(reflect.TypeOf(tt.res)).Interface()


### PR DESCRIPTION
This use case for this is to provide a human readable representation of it through the upcoming `plz query config`.

Example:
```
[please]
version=16.12.1
toolsurl=
location=/home/ttristao/code/please/plz-out/please
selfupdate=true
downloadlocation=https://get.please.build
numoldversions=10
autoclean=true
numthreads=14
defaultrepo=

...

[build]
arch=linux_amd64
timeout=600000000000
path=/usr/local/bin
path=/usr/bin
path=/bin
config=opt
fallbackconfig=opt
lang=en_GB.UTF-8
sandbox=false
xattrs=true
pleasesandboxtool=
nonce=1402
httpproxy=
hashfunction=sha256
exitonerror=false
linkgeneratedsources=false

...

[size "small"]
timeout=60000000000
timeoutname=short
[size "medium"]
timeout=300000000000
timeoutname=moderate

...

[cover]
fileextension=.go
fileextension=.py
fileextension=.java
fileextension=.tsx
fileextension=.ts
fileextension=.js
fileextension=.cc
fileextension=.h
fileextension=.c
excludeextension=.pb.go
excludeextension=_pb2.py
excludeextension=.spec.tsx
excludeextension=.spec.ts
excludeextension=.spec.js
excludeextension=.pb.cc
excludeextension=.pb.h
excludeextension=_test.py
excludeextension=_test.go
excludeextension=_pb.go
excludeextension=_bindata.go
excludeextension=_test_main.cc

...

[go]
gotool=//third_party/go:toolchain|go
goroot=
gopath=
importpath=github.com/thought-machine/please
cgocctool=gcc
cgoenabled=
filtertool=//tools/please_go_filter
pleasegotool=//tools/please_go
embedtool=//tools/please_go_embed
delvetool=dlv
defaultstatic=false
gotestrootcompat=false
cflags=
ldflags=

...

[alias "bootstrap"]
cmd=run //:bootstrap --
desc=Bootstraps Please from scratch
positionallabels=false

[alias "bootonly"]
cmd=run //:bootstrap -- --skip_tests
desc=Bootstraps Please, but does not run any tests.
positionallabels=false
```