### PR TITLE
Inject section after comments if file only has comments in it

### DIFF
--- a/ast/ast_test.go
+++ b/ast/ast_test.go
@@ -549,6 +549,20 @@ broccoli = green
 	require.Equal(t, expected, string(convertASTToBytes(file)))
 }
 
+func TestInjectFieldIntoCommentFile(t *testing.T) {
+	config := `; comment
+; preamble
+`
+	file := Read(strings.NewReader(config))
+	file = InjectField(file, "foo", "bar", "Section", "baz", false)
+	expected := `; comment
+; preamble
+[Section "baz"]
+foo = bar
+`
+	require.Equal(t, expected, string(convertASTToBytes(file)))
+}
+
 const chunkSize = 64000
 
 func deepCompare(file1, file2 string) bool {

--- a/ast/modify.go
+++ b/ast/modify.go
@@ -17,6 +17,7 @@ func InjectField(f File, fieldName, fieldValue, sectionName, subsectionName stri
 
 		// Move file's comments to this section's CommentsBefore
 		s.CommentsBefore = f.CommentsAfter
+		s.CommentsBefore = append(s.CommentsBefore, &Comment{})
 		f.CommentsAfter = nil
 
 		f.Sections = append(f.Sections, &s)

--- a/ast/modify.go
+++ b/ast/modify.go
@@ -14,6 +14,11 @@ func InjectField(f File, fieldName, fieldValue, sectionName, subsectionName stri
 	if len(f.Sections) == 0 {
 		s := makeSection(sectionName, subsectionName)
 		s.Fields = append(s.Fields, &fi)
+
+		// Move file's comments to this section's CommentsBefore
+		s.CommentsBefore = f.CommentsAfter
+		f.CommentsAfter = nil
+
 		f.Sections = append(f.Sections, &s)
 		return f
 	}


### PR DESCRIPTION
If a file only has comments in it, we should treat this as a preamble. So any sections we add to the file should come after.