### PR TITLE
Add CommentsAfter field to Section struct and API for adding them.

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -24,6 +24,7 @@ type Section struct {
 	Key            string // Section identifier
 	Fields         []*Field
 	CommentsBefore []*Comment // Any comments or whitespace between this field and whatever came before
+	CommentsAfter  []*Comment // Comments or whitespace that should specifically appear immediately after the section heading
 }
 
 type Field struct {

--- a/ast/ast_test.go
+++ b/ast/ast_test.go
@@ -528,7 +528,7 @@ onion = brown
 func TestDeleteFieldWithValue(t *testing.T) {
 	config := `[fruits]
 fruit = apple ;; a comment
-fruit = papaya 
+fruit = papaya
 
 [food "vegetables"]
 broccoli = green
@@ -546,6 +546,34 @@ broccoli = green
 `
 	require.Equal(t, 1, file.Sections[0].numFields())
 	require.Equal(t, 1, file.Sections[1].numFields())
+	require.Equal(t, expected, string(convertASTToBytes(file)))
+}
+
+func TestAddCommentsAfterToSection(t *testing.T) {
+	config := `[fruits]
+fruit = apple ;; a comment
+fruit = papaya
+
+[food "vegetables"]
+broccoli = green
+broccoli = red
+`
+	file := Read(strings.NewReader(config))
+	file, ok := AddCommentsAfterToSection(file, []string{"; comment1"}, "fruits", "")
+	require.True(t, ok)
+	file, ok = AddCommentsAfterToSection(file, []string{"comment1", "comment2"}, "food", "vegetables")
+	require.True(t, ok)
+	expected := `[fruits]
+; comment1
+fruit = apple ;; a comment
+fruit = papaya
+
+[food "vegetables"]
+; comment1
+; comment2
+broccoli = green
+broccoli = red
+`
 	require.Equal(t, expected, string(convertASTToBytes(file)))
 }
 

--- a/ast/ast_test.go
+++ b/ast/ast_test.go
@@ -559,10 +559,10 @@ broccoli = green
 broccoli = red
 `
 	file := Read(strings.NewReader(config))
-	file, ok := AddCommentsAfterToSection(file, []string{"; comment1"}, "fruits", "")
-	require.True(t, ok)
-	file, ok = AddCommentsAfterToSection(file, []string{"comment1", "comment2"}, "food", "vegetables")
-	require.True(t, ok)
+	// file, ok := AddCommentsAfterToSection(file, []string{"; comment1"}, "fruits", "")
+	// require.True(t, ok)
+	// file, ok = AddCommentsAfterToSection(file, []string{"comment1", "comment2"}, "food", "vegetables")
+	// require.True(t, ok)
 	expected := `[fruits]
 ; comment1
 fruit = apple ;; a comment

--- a/ast/ast_test.go
+++ b/ast/ast_test.go
@@ -559,10 +559,10 @@ broccoli = green
 broccoli = red
 `
 	file := Read(strings.NewReader(config))
-	// file, ok := AddCommentsAfterToSection(file, []string{"; comment1"}, "fruits", "")
-	// require.True(t, ok)
-	// file, ok = AddCommentsAfterToSection(file, []string{"comment1", "comment2"}, "food", "vegetables")
-	// require.True(t, ok)
+	file, ok := AddCommentsAfterToSection(file, []string{"; comment1"}, "fruits", "")
+	require.True(t, ok)
+	file, ok = AddCommentsAfterToSection(file, []string{"comment1", "comment2"}, "food", "vegetables")
+	require.True(t, ok)
 	expected := `[fruits]
 ; comment1
 fruit = apple ;; a comment

--- a/ast/modify.go
+++ b/ast/modify.go
@@ -65,25 +65,6 @@ func MakeNewSection(f File, sectionName, subsectionName string) (File, bool) {
 	return f, ok
 }
 
-// AddCommentsAfterToSection adds comments to the 'CommentsAfter' member of a Section.
-// This is intended to be used for comments that come immediately after a section heading.
-// Returns not ok if the section does not exist.
-func AddCommentsAfterToSection(f File, comments []string, sectionName, subsectionName string) (File, bool) {
-	ok := false
-	sectionKey := getKeyFromSectionAndSubsection(sectionName, subsectionName)
-	for i, s := range f.Sections {
-		if s.Key == sectionKey {
-			ok = true
-			for _, c_str := range comments {
-				c := &Comment{c_str}
-				f.Sections[i].CommentsAfter = append(f.Sections[i].CommentsAfter, c)
-			}
-		}
-	}
-
-	return f, ok
-}
-
 // AppendFieldToSection appends a field to a section with no knowledge of whether the field is
 // repeatable or not. Creates a new section if section does not exist
 func AppendFieldToSection(f File, fieldName, fieldValue, sectionName, subsectionName string) File {

--- a/ast/modify.go
+++ b/ast/modify.go
@@ -65,6 +65,25 @@ func MakeNewSection(f File, sectionName, subsectionName string) (File, bool) {
 	return f, ok
 }
 
+// AddCommentsAfterToSection adds comments to the 'CommentsAfter' member of a Section.
+// This is intended to be used for comments that come immediately after a section heading.
+// Returns not ok if the section does not exist.
+func AddCommentsAfterToSection(f File, comments []string, sectionName, subsectionName string) (File, bool) {
+	ok := false
+	sectionKey := getKeyFromSectionAndSubsection(sectionName, subsectionName)
+	for i, s := range f.Sections {
+		if s.Key == sectionKey {
+			ok = true
+			for _, c_str := range comments {
+				c := &Comment{c_str}
+				f.Sections[i].CommentsAfter = append(f.Sections[i].CommentsAfter, c)
+			}
+		}
+	}
+
+	return f, ok
+}
+
 // AppendFieldToSection appends a field to a section with no knowledge of whether the field is
 // repeatable or not. Creates a new section if section does not exist
 func AppendFieldToSection(f File, fieldName, fieldValue, sectionName, subsectionName string) File {

--- a/ast/modify.go
+++ b/ast/modify.go
@@ -47,6 +47,43 @@ func InjectField(f File, fieldName, fieldValue, sectionName, subsectionName stri
 	return f
 }
 
+// MakeNewSection writes a new section heading to the file. Returns !ok if section already exists.
+func MakeNewSection(f File, sectionName, subsectionName string) (File, bool) {
+	ok := true
+	sectionKey := getKeyFromSectionAndSubsection(sectionName, subsectionName)
+	for _, s := range f.Sections {
+		if s.Key == sectionKey {
+			ok = false
+		}
+	}
+
+	if ok {
+		newSection := makeSection(sectionName, subsectionName)
+		f.Sections = append(f.Sections, &newSection)
+	}
+
+	return f, ok
+}
+
+// AddCommentsAfterToSection adds comments to the 'CommentsAfter' member of a Section.
+// This is intended to be used for comments that come immediately after a section heading.
+// Returns not ok if the section does not exist.
+func AddCommentsAfterToSection(f File, comments []string, sectionName, subsectionName string) (File, bool) {
+	ok := false
+	sectionKey := getKeyFromSectionAndSubsection(sectionName, subsectionName)
+	for i, s := range f.Sections {
+		if s.Key == sectionKey {
+			ok = true
+			for _, c_str := range comments {
+				c := &Comment{c_str}
+				f.Sections[i].CommentsAfter = append(f.Sections[i].CommentsAfter, c)
+			}
+		}
+	}
+
+	return f, ok
+}
+
 // AppendFieldToSection appends a field to a section with no knowledge of whether the field is
 // repeatable or not. Creates a new section if section does not exist
 func AppendFieldToSection(f File, fieldName, fieldValue, sectionName, subsectionName string) File {

--- a/ast/write.go
+++ b/ast/write.go
@@ -3,6 +3,7 @@ package ast
 import (
 	"log"
 	"os"
+	"strings"
 )
 
 // Write writes an AST file to a file on disk.
@@ -44,6 +45,13 @@ func (s Section) toBytes() []byte {
 		ret += c.Str + "\n"
 	}
 	ret += s.getHeadingStr() + "\n"
+	for _, c := range s.CommentsAfter {
+		if strings.HasPrefix(c.Str, ";") {
+			ret += c.Str + "\n"
+		} else {
+			ret += "; " + c.Str + "\n"
+		}
+	}
 	return []byte(ret)
 }
 


### PR DESCRIPTION
This should fix the issue seen in Please where, if you have a section followed by just comments, and then inject another section, the second section appears in between the first section heading and its comments.

Not 100% sure about this. This is something we can only make use of once the file has been read into the AST. The reader still only interprets comments and whitespace as belonging to the thing _after_. But I don't see how else you could do it, unless you had a flag on `Read` that specifies whether all comments and whitespace should belong to the thing after or the thing before.