### PR TITLE
Revert comments after section

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -24,7 +24,6 @@ type Section struct {
 	Key            string // Section identifier
 	Fields         []*Field
 	CommentsBefore []*Comment // Any comments or whitespace between this field and whatever came before
-	CommentsAfter  []*Comment // Comments or whitespace that should specifically appear immediately after the section heading
 }
 
 type Field struct {

--- a/ast/ast_test.go
+++ b/ast/ast_test.go
@@ -548,34 +548,6 @@ broccoli = green
 	require.Equal(t, expected, string(convertASTToBytes(file)))
 }
 
-func TestAddCommentsAfterToSection(t *testing.T) {
-	config := `[fruits]
-fruit = apple ;; a comment
-fruit = papaya
-
-[food "vegetables"]
-broccoli = green
-broccoli = red
-`
-	file := Read(strings.NewReader(config))
-	file, ok := AddCommentsAfterToSection(file, []string{"; comment1"}, "fruits", "")
-	require.True(t, ok)
-	file, ok = AddCommentsAfterToSection(file, []string{"comment1", "comment2"}, "food", "vegetables")
-	require.True(t, ok)
-	expected := `[fruits]
-; comment1
-fruit = apple ;; a comment
-fruit = papaya
-
-[food "vegetables"]
-; comment1
-; comment2
-broccoli = green
-broccoli = red
-`
-	require.Equal(t, expected, string(convertASTToBytes(file)))
-}
-
 func TestAppendBlankLineToFile(t *testing.T) {
 	config := `[fruits]
 fruit = apple ;; a comment

--- a/ast/modify.go
+++ b/ast/modify.go
@@ -53,43 +53,6 @@ func InjectField(f File, fieldName, fieldValue, sectionName, subsectionName stri
 	return f
 }
 
-// MakeNewSection writes a new section heading to the file. Returns !ok if section already exists.
-func MakeNewSection(f File, sectionName, subsectionName string) (File, bool) {
-	ok := true
-	sectionKey := getKeyFromSectionAndSubsection(sectionName, subsectionName)
-	for _, s := range f.Sections {
-		if s.Key == sectionKey {
-			ok = false
-		}
-	}
-
-	if ok {
-		newSection := makeSection(sectionName, subsectionName)
-		f.Sections = append(f.Sections, &newSection)
-	}
-
-	return f, ok
-}
-
-// AddCommentsAfterToSection adds comments to the 'CommentsAfter' member of a Section.
-// This is intended to be used for comments that come immediately after a section heading.
-// Returns not ok if the section does not exist.
-func AddCommentsAfterToSection(f File, comments []string, sectionName, subsectionName string) (File, bool) {
-	ok := false
-	sectionKey := getKeyFromSectionAndSubsection(sectionName, subsectionName)
-	for i, s := range f.Sections {
-		if s.Key == sectionKey {
-			ok = true
-			for _, c_str := range comments {
-				c := &Comment{c_str}
-				f.Sections[i].CommentsAfter = append(f.Sections[i].CommentsAfter, c)
-			}
-		}
-	}
-
-	return f, ok
-}
-
 // AppendBlankLine appends an empty line to the file.
 func AppendBlankLineToFile(f File) File {
 	f.CommentsAfter = append(f.CommentsAfter, &Comment{})

--- a/ast/modify.go
+++ b/ast/modify.go
@@ -53,6 +53,24 @@ func InjectField(f File, fieldName, fieldValue, sectionName, subsectionName stri
 	return f
 }
 
+// MakeNewSection writes a new section heading to the file. Returns !ok if section already exists.
+func MakeNewSection(f File, sectionName, subsectionName string) (File, bool) {
+	ok := true
+	sectionKey := getKeyFromSectionAndSubsection(sectionName, subsectionName)
+	for _, s := range f.Sections {
+		if s.Key == sectionKey {
+			ok = false
+		}
+	}
+
+	if ok {
+		newSection := makeSection(sectionName, subsectionName)
+		f.Sections = append(f.Sections, &newSection)
+	}
+
+	return f, ok
+}
+
 // AppendBlankLine appends an empty line to the file.
 func AppendBlankLineToFile(f File) File {
 	f.CommentsAfter = append(f.CommentsAfter, &Comment{})

--- a/ast/write.go
+++ b/ast/write.go
@@ -3,7 +3,6 @@ package ast
 import (
 	"log"
 	"os"
-	"strings"
 )
 
 // Write writes an AST file to a file on disk.
@@ -45,13 +44,6 @@ func (s Section) toBytes() []byte {
 		ret += c.Str + "\n"
 	}
 	ret += s.getHeadingStr() + "\n"
-	for _, c := range s.CommentsAfter {
-		if strings.HasPrefix(c.Str, ";") {
-			ret += c.Str + "\n"
-		} else {
-			ret += "; " + c.Str + "\n"
-		}
-	}
 	return []byte(ret)
 }
 


### PR DESCRIPTION
Turns out we didn't need this. And don't think it's very useful because it only persists as long as the AST object is around, which generally isn't very long. As soon as we read again, the comments will go back to belonging to the thing after.