### PR TITLE
Update ast.Read() to handle empty config values and curly braces

### DIFF
--- a/ast/ast_test.go
+++ b/ast/ast_test.go
@@ -668,18 +668,15 @@ foo = bar
 
 func TestConfigFieldRegex(t *testing.T) {
 	config := `[section]
-key = value
-key =
-key =value
-key = value ;comment
 key=;comment
 key={value}
 key = { value  }{foo}
 `
 	file := Read(strings.NewReader(config))
-	require.Equal(t, 7, len(file.Sections[0].Fields))
-	require.Equal(t, "{value}", file.Sections[0].Fields[5].Value)
-	require.Equal(t, "{ value  }{foo}", file.Sections[0].Fields[6].Value)
+	require.Equal(t, 3, len(file.Sections[0].Fields))
+	require.Equal(t, "", file.Sections[0].Fields[0].Value)
+	require.Equal(t, "{value}", file.Sections[0].Fields[1].Value)
+	require.Equal(t, "{ value  }{foo}", file.Sections[0].Fields[2].Value)
 }
 
 const chunkSize = 64000

--- a/ast/ast_test.go
+++ b/ast/ast_test.go
@@ -666,16 +666,20 @@ foo = bar
 	require.Equal(t, expected, string(convertASTToBytes(file)))
 }
 
-func TestEmptyConfigValue(t *testing.T) {
+func TestConfigFieldRegex(t *testing.T) {
 	config := `[section]
 key = value
 key =
 key =value
 key = value ;comment
 key=;comment
+key={value}
+key = { value  }{foo}
 `
 	file := Read(strings.NewReader(config))
-	require.Equal(t, 5, len(file.Sections[0].Fields))
+	require.Equal(t, 7, len(file.Sections[0].Fields))
+	require.Equal(t, "{value}", file.Sections[0].Fields[5].Value)
+	require.Equal(t, "{ value  }{foo}", file.Sections[0].Fields[6].Value)
 }
 
 const chunkSize = 64000

--- a/ast/ast_test.go
+++ b/ast/ast_test.go
@@ -666,6 +666,18 @@ foo = bar
 	require.Equal(t, expected, string(convertASTToBytes(file)))
 }
 
+func TestEmptyConfigValue(t *testing.T) {
+	config := `[section]
+key = value
+key =
+key =value
+key = value ;comment
+key=;comment
+`
+	file := Read(strings.NewReader(config))
+	require.Equal(t, 5, len(file.Sections[0].Fields))
+}
+
 const chunkSize = 64000
 
 func deepCompare(file1, file2 string) bool {

--- a/ast/ast_test.go
+++ b/ast/ast_test.go
@@ -668,15 +668,17 @@ foo = bar
 
 func TestConfigFieldRegex(t *testing.T) {
 	config := `[section]
+key =  
 key=;comment
 key={value}
 key = { value  }{foo}
 `
 	file := Read(strings.NewReader(config))
-	require.Equal(t, 3, len(file.Sections[0].Fields))
-	require.Equal(t, "", file.Sections[0].Fields[0].Value)
-	require.Equal(t, "{value}", file.Sections[0].Fields[1].Value)
-	require.Equal(t, "{ value  }{foo}", file.Sections[0].Fields[2].Value)
+	require.Equal(t, 4, len(file.Sections[0].Fields))
+	require.Equal(t, "", file.Sections[0].Fields[1].Value)
+	require.Equal(t, "", file.Sections[0].Fields[1].Value)
+	require.Equal(t, "{value}", file.Sections[0].Fields[2].Value)
+	require.Equal(t, "{ value  }{foo}", file.Sections[0].Fields[3].Value)
 }
 
 const chunkSize = 64000

--- a/ast/ast_test.go
+++ b/ast/ast_test.go
@@ -675,7 +675,7 @@ key = { value  }{foo}
 `
 	file := Read(strings.NewReader(config))
 	require.Equal(t, 4, len(file.Sections[0].Fields))
-	require.Equal(t, "", file.Sections[0].Fields[1].Value)
+	require.Equal(t, "", file.Sections[0].Fields[0].Value)
 	require.Equal(t, "", file.Sections[0].Fields[1].Value)
 	require.Equal(t, "{value}", file.Sections[0].Fields[2].Value)
 	require.Equal(t, "{ value  }{foo}", file.Sections[0].Fields[3].Value)

--- a/ast/read.go
+++ b/ast/read.go
@@ -13,7 +13,7 @@ func Read(file io.Reader) File {
 	scanner := bufio.NewScanner(file)
 	commentBuffer := make([]*Comment, 0, 64)
 	fieldBuffer := make([]*Field, 0, 64)
-	fieldRegex := regexp.MustCompile(`^ *[a-zA-Z0-9_.-]+ *= *[a-zA-Z0-9_ /.-]`)
+	fieldRegex := regexp.MustCompile(`^ *[a-zA-Z0-9_.-]+ *= *`)
 	sectionRegex := regexp.MustCompile(`^ *\[[a-zA-Z0-9_" .-]+\]`)
 	for scanner.Scan() {
 		line := scanner.Text()

--- a/ast/read.go
+++ b/ast/read.go
@@ -68,7 +68,7 @@ func Read(file io.Reader) File {
 
 // tryMakeFieldFromString takes a field string and tries to return an AST field
 func tryMakeFieldFromString(s string) (*Field, bool) {
-	reg := regexp.MustCompile(`^ *([a-zA-Z0-9_.-]+) *= *([a-zA-Z0-9_@&,|"~<>/:= +.-]+)?( *;.*)?`)
+	reg := regexp.MustCompile(`^ *([a-zA-Z0-9_.-]+) *= *([a-zA-Z0-9_@{}&,|"~<>/:= +.-]+)?( *;.*)?`)
 	matches := reg.FindStringSubmatch(s)
 	if len(matches) == 0 {
 		return nil, false


### PR DESCRIPTION
It's possible for a config field to not have a value. This change updates the field regex to handle that case.