### PR TITLE
Allow setting empty values in SSM sections

### DIFF
--- a/read_test.go
+++ b/read_test.go
@@ -474,7 +474,7 @@ func TestStringStringMapSection(t *testing.T) {
 	[section]
 	key = value
 	key2 = value2
-    key3 =`
+	key3 =`
 	err := ReadStringInto(res, cfg)
 	if err != nil {
 		t.Error(err)

--- a/read_test.go
+++ b/read_test.go
@@ -473,7 +473,8 @@ func TestStringStringMapSection(t *testing.T) {
 	cfg := `
 	[section]
 	key = value
-	key2 = value2`
+	key2 = value2
+    key3 =`
 	err := ReadStringInto(res, cfg)
 	if err != nil {
 		t.Error(err)
@@ -483,6 +484,9 @@ func TestStringStringMapSection(t *testing.T) {
 	}
 	if res.Section["key2"] != "value2" {
 		t.Errorf("res.Section.Name=%q; want %q", res.Section["key2"], "value2")
+	}
+	if val, present := res.Section["key3"]; !present || val != "" {
+		t.Errorf("res.Section.Name=%q present=%v; want %q", res.Section["key3"], present, "")
 	}
 }
 

--- a/set.go
+++ b/set.go
@@ -239,12 +239,10 @@ func set(c *warnings.Collector, cfg interface{}, sect, sub, name string,
 			if vSect.IsNil() {
 				vSect.Set(reflect.MakeMap(vst))
 			}
-			if value != "" {
-				if sub != "" {
-					vSect.SetMapIndex(reflect.ValueOf(sub+" "+name), reflect.ValueOf(value))
-				} else {
-					vSect.SetMapIndex(reflect.ValueOf(name), reflect.ValueOf(value))
-				}
+			if sub != "" {
+				vSect.SetMapIndex(reflect.ValueOf(sub+" "+name), reflect.ValueOf(value))
+			} else {
+				vSect.SetMapIndex(reflect.ValueOf(name), reflect.ValueOf(value))
 			}
 			return nil
 		}


### PR DESCRIPTION
I don't think there is a strong reason to prohibit this, and the question has come up internally of why these don't appear. I think it's more logical that they appear in the map as an empty string if explicitly set.