### PR TITLE
Filter SSM items to require a name

### DIFF
--- a/read_test.go
+++ b/read_test.go
@@ -488,6 +488,9 @@ func TestStringStringMapSection(t *testing.T) {
 	if val, present := res.Section["key3"]; !present || val != "" {
 		t.Errorf("res.Section.Name=%q present=%v; want %q", res.Section["key3"], present, "")
 	}
+	if len(res.Section) != 3 {
+		t.Errorf("Wrong number of items in section; expected 3, got %d", len(res.Section))
+	}
 }
 
 func TestFatalOnly(t *testing.T) {

--- a/set.go
+++ b/set.go
@@ -239,10 +239,12 @@ func set(c *warnings.Collector, cfg interface{}, sect, sub, name string,
 			if vSect.IsNil() {
 				vSect.Set(reflect.MakeMap(vst))
 			}
-			if sub != "" {
-				vSect.SetMapIndex(reflect.ValueOf(sub+" "+name), reflect.ValueOf(value))
-			} else {
-				vSect.SetMapIndex(reflect.ValueOf(name), reflect.ValueOf(value))
+			if name != "" {
+				if sub != "" {
+					vSect.SetMapIndex(reflect.ValueOf(sub+" "+name), reflect.ValueOf(value))
+				} else {
+					vSect.SetMapIndex(reflect.ValueOf(name), reflect.ValueOf(value))
+				}
 			}
 			return nil
 		}


### PR DESCRIPTION
Fix to #16 - it was producing empty items (not quite sure why but this seems like what the test might have originally been checking for)