### PR TITLE
Emit map fields in sorted order

### DIFF
--- a/.github/workflows/release.v1.yaml
+++ b/.github/workflows/release.v1.yaml
@@ -9,7 +9,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: '^1.23.0'
 
     - name: Build
       run: go build -v ./...

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,12 @@ module github.com/please-build/gcfg
 go 1.23
 
 require (
-	github.com/stretchr/testify v1.7.0 // indirect
+	github.com/stretchr/testify v1.7.0
 	gopkg.in/warnings.v0 v0.1.2
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/please-build/gcfg
 
-go 1.16
+go 1.23
 
 require (
 	github.com/stretchr/testify v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,10 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=

--- a/json.go
+++ b/json.go
@@ -45,13 +45,12 @@ func RawJSON(config interface{}) ([]byte, error) {
 				res = append(res, fmt.Sprintf("\"%s\":%s,", iniFieldName, innerRes)...)
 			} else if fieldStruct.Type.Elem().Kind() == reflect.Ptr && fieldStruct.Type.Elem().Elem().Kind() == reflect.Struct {
 				res = append(res, `"`+iniFieldName+`":{`...)
-				iter := fieldValue.MapRange()
-				for iter.Next() {
-					innerRes, err := marshalStruct(iter.Value().Elem())
+				for k, v := range iterReflectMap(fieldValue) {
+					innerRes, err := marshalStruct(v.Elem())
 					if err != nil {
 						return nil, err
 					}
-					res = append(res, fmt.Sprintf("\"%s\":%s,", iter.Key(), innerRes)...)
+					res = append(res, fmt.Sprintf("\"%s\":%s,", k, innerRes)...)
 				}
 				res = append(bytes.TrimSuffix(res, []byte(",")), `},`...)
 			} else {
@@ -82,13 +81,12 @@ func marshalStruct(fieldValue reflect.Value) ([]byte, error) {
 				return nil, fmt.Errorf("Expected either a map[string]string or map[string][]string type, but instead got %s\n", subfieldStruct.Type)
 			}
 
-			iter := subfieldValue.MapRange()
-			for iter.Next() {
-				innerRes, err := json.Marshal(iter.Value().Interface())
+			for k, v := range iterReflectMap(subfieldValue) {
+				innerRes, err := json.Marshal(v.Interface())
 				if err != nil {
 					return nil, err
 				}
-				res = append(res, fmt.Sprintf("\"%s\":%s,", iter.Key(), innerRes)...)
+				res = append(res, fmt.Sprintf("\"%s\":%s,", k, innerRes)...)
 			}
 			res = bytes.TrimSuffix(res, []byte(","))
 		} else {

--- a/stringify.go
+++ b/stringify.go
@@ -56,14 +56,13 @@ func Stringify(config interface{}) (string, error) {
 					s += "\n"
 				}
 			} else if fieldStruct.Type.Elem().Kind() == reflect.Ptr && fieldStruct.Type.Elem().Elem().Kind() == reflect.Struct {
-				iter := fieldValue.MapRange()
-				for iter.Next() {
-					iniVariableLines, err := stringifyStructFields(iter.Value().Elem())
+				for k, v := range iterReflectMap(fieldValue) {
+					iniVariableLines, err := stringifyStructFields(v.Elem())
 					if err != nil {
 						return "", err
 					}
 
-					s += iniSectionLine(iniFieldName, iter.Key().String())
+					s += iniSectionLine(iniFieldName, k)
 					s += iniVariableLines
 					s += "\n"
 				}
@@ -237,6 +236,22 @@ func iterMap[K cmp.Ordered, V any](m map[K]V) iter.Seq2[K, V] {
 	return func(yield func(K, V) bool) {
 		for _, k := range keys {
 			if !yield(k, m[k]) {
+				return
+			}
+		}
+	}
+}
+
+// iterReflectMap returns an iterator over the values of a reflected map, in order of keys.
+// It panics if v's Kind is not reflect.Map or its keys are not strings.
+func iterReflectMap(v reflect.Value) iter.Seq2[string, reflect.Value] {
+	keys := v.MapKeys()
+	slices.SortFunc(keys, func(a, b reflect.Value) int {
+		return strings.Compare(a.Interface().(string), b.Interface().(string))
+	})
+	return func(yield func(string, reflect.Value) bool) {
+		for _, k := range keys {
+			if !yield(k.Interface().(string), v.MapIndex(k)) {
 				return
 			}
 		}

--- a/stringify.go
+++ b/stringify.go
@@ -93,10 +93,9 @@ func stringifyStructFields(value reflect.Value) (string, error) {
 				return "", fmt.Errorf("Expected either a map[string]string or map[string][]string type, but instead got %s\n", fieldStruct.Type)
 			}
 
-			iter := fieldValue.MapRange()
-			for iter.Next() {
-				iterateMaybeSlice(iter.Value(), func(innerValue reflect.Value) error {
-					s += iniVariableLine(iter.Key().String(), innerValue.String())
+			for k, v := range iterReflectMap(fieldValue) {
+				iterateMaybeSlice(v, func(innerValue reflect.Value) error {
+					s += iniVariableLine(k, innerValue.String())
 					return nil
 				})
 			}

--- a/stringify.go
+++ b/stringify.go
@@ -1,10 +1,14 @@
 package gcfg
 
 import (
+	"cmp"
 	"encoding"
 	"fmt"
+	"iter"
+	"maps"
 	"math/big"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"unicode"
@@ -44,9 +48,9 @@ func Stringify(config interface{}) (string, error) {
 			}
 
 			if fieldStruct.Type.Elem().Kind() == reflect.String {
-				for subsection, variables := range decodeStringMap(fieldValue) {
+				for subsection, variables := range iterMap(decodeStringMap(fieldValue)) {
 					s += iniSectionLine(iniFieldName, subsection)
-					for variable, value := range variables {
+					for variable, value := range iterMap(variables) {
 						s += iniVariableLine(variable, value)
 					}
 					s += "\n"
@@ -224,4 +228,17 @@ func iterateMaybeSlice(value reflect.Value, callback func(reflect.Value) error) 
 		}
 	}
 	return nil
+}
+
+// iterMap returns an iterator over the entries of a map, in order of keys.
+func iterMap[K cmp.Ordered, V any](m map[K]V) iter.Seq2[K, V] {
+	keys := slices.Collect(maps.Keys(m))
+	slices.Sort(keys)
+	return func(yield func(K, V) bool) {
+		for _, k := range keys {
+			if !yield(k, m[k]) {
+				return
+			}
+		}
+	}
 }

--- a/stringify_test.go
+++ b/stringify_test.go
@@ -179,3 +179,32 @@ key1 = value3
 	assert.NoError(t, err)
 	assert.Equal(t, res, expectedResult)
 }
+
+func TestStringifyMapOrder(t *testing.T) {
+	config := &struct {
+		Foo map[string]string
+		Bar map[string]*struct {
+			Baz string
+		}
+	}{
+		Foo: map[string]string{
+			"a b": "1",
+			"a c": "2",
+			"d e": "3",
+			"d f": "4",
+		},
+	}
+	const expected = `[foo "a"]
+b = 1
+c = 2
+
+[foo "d"]
+e = 3
+f = 4
+
+`
+
+	res, err := Stringify(config)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, res)
+}

--- a/stringify_test.go
+++ b/stringify_test.go
@@ -193,6 +193,12 @@ func TestStringifyMapOrder(t *testing.T) {
 			"d e": "3",
 			"d f": "4",
 		},
+		Bar: map[string]*struct {
+			Baz string
+		}{
+			"k": {"m"},
+			"l": {"n"},
+		},
 	}
 	const expected = `[foo "a"]
 b = 1
@@ -201,6 +207,12 @@ c = 2
 [foo "d"]
 e = 3
 f = 4
+
+[bar "k"]
+baz = m
+
+[bar "l"]
+baz = n
 
 `
 


### PR DESCRIPTION
Currently they come out in arbitrary order, so reading & rewriting a file isn't stable.

This ups the required Go version significantly in order to get iterators etc. I imagine it could be written without but would be considerably less nice, and I assume 1.23 is ok since it's the oldest currently supported version upstream.