### PR TITLE
Allow ignoring fields tagged with - on serialisation

### DIFF
--- a/json.go
+++ b/json.go
@@ -25,6 +25,9 @@ func RawJSON(config interface{}) ([]byte, error) {
 		}
 
 		iniFieldName := iniKey(fieldStruct)
+		if iniFieldName == ignoreKey {
+			continue
+		}
 
 		if fieldValue.Kind() == reflect.Struct {
 			innerRes, err := marshalStruct(fieldValue)
@@ -94,7 +97,9 @@ func marshalStruct(fieldValue reflect.Value) ([]byte, error) {
 			if err != nil {
 				return nil, err
 			}
-			res = append(res, fmt.Sprintf("\"%s\":%s", iniKey(subfieldStruct), innerRes)...)
+			if key := iniKey(subfieldStruct); key != ignoreKey {
+				res = append(res, fmt.Sprintf("\"%s\":%s", key, innerRes)...)
+			}
 		}
 
 		res = append(res, ',')

--- a/json_test.go
+++ b/json_test.go
@@ -169,3 +169,23 @@ func TestRawJson5(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, expectedResult, out.String())
 }
+
+func TestJSONIgnoresDash(t *testing.T) {
+	config := &struct {
+		Foo struct {
+			Bar string
+			Baz string `gcfg:"-"`
+		} `gcfg:"foo"`
+		Bar struct {
+			Quux string
+		} `gcfg:"-"`
+	}{}
+	config.Foo.Bar = "bar"
+	config.Foo.Baz = "baz"
+	config.Bar.Quux = "quux"
+	const expected = `{"foo":{"bar":"bar",}}`
+	v, err := RawJSON(config)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, string(v))
+
+}

--- a/stringify.go
+++ b/stringify.go
@@ -15,6 +15,9 @@ import (
 	"unicode/utf8"
 )
 
+// ignoreKey is the struct key that indicates we ignore the field
+const ignoreKey = "-"
+
 // Stringify returns the ini format representation of `config`.
 func Stringify(config interface{}) (string, error) {
 	configPtr := reflect.ValueOf(config)
@@ -32,6 +35,9 @@ func Stringify(config interface{}) (string, error) {
 		}
 
 		iniFieldName := iniKey(fieldStruct)
+		if iniFieldName == ignoreKey {
+			continue
+		}
 
 		if fieldValue.Kind() == reflect.Struct {
 			iniVariableLines, err := stringifyStructFields(fieldValue)
@@ -105,7 +111,9 @@ func stringifyStructFields(value reflect.Value) (string, error) {
 				if err != nil {
 					return err
 				}
-				s += iniVariableLine(iniKey(fieldStruct), res)
+				if key := iniKey(fieldStruct); key != ignoreKey {
+					s += iniVariableLine(key, res)
+				}
 				return nil
 			}); err != nil {
 				return "", err

--- a/stringify_test.go
+++ b/stringify_test.go
@@ -220,3 +220,25 @@ baz = n
 	assert.NoError(t, err)
 	assert.Equal(t, expected, res)
 }
+
+func TestStringifyIgnoresDash(t *testing.T) {
+	config := &struct {
+		Foo struct {
+			Bar string
+			Baz string `gcfg:"-"`
+		} `gcfg:"foo"`
+		Bar struct {
+			Quux string
+		} `gcfg:"-"`
+	}{}
+	config.Foo.Bar = "bar"
+	config.Foo.Baz = "baz"
+	config.Bar.Quux = "quux"
+	const expected = `[foo]
+bar = bar
+
+`
+	res, err := Stringify(config)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, res)
+}


### PR DESCRIPTION
This is similar to the approach used by packages like `encoding/json` to opt a field out of serialisation.

I don't think I have to do anything on the read side for this to work; `-` isn't a legal section or field name, so once you set `gcfg:"-"` it implicitly can't be read into.